### PR TITLE
move up related code from persistence-redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "aedes-packet": "^2.1.0",
     "aedes-persistence": "^7.1.1",
     "fastparallel": "^2.3.0",
+    "from2": "^2.3.0",
     "multistream": "^4.0.0",
     "qlobber": "^3.1.0"
   }


### PR DESCRIPTION
This cleans aedes-persistence-redis from trie logic available here.
This later helps me to create a clustered version of aedes-cached-persistence