### PR TITLE
WIP: Fix tests for aedes-persistence mongodb

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -1,5 +1,5 @@
 'use strict'
 
-var parent = require('aedes-persistence/abstract')
+var parent = require('../aedes-persistence/abstract')
 
 module.exports = parent


### PR DESCRIPTION
When storing docs with mongodb, if a key has an `undefined` value that will be converted to `null` when stored and this makes test fails. 

This PR paired with another on aedes-persistence-mongodb that deletes undefined messageIds before storing a doc will fix the tests.

There is still one test that is failing but I need your help:

```
⨯ add outgoing packet as a string and pump
  not ok 225 should be equal
    ---
      operator: equal
      expected: 2
      actual:   0
      at: done (/aedes-persistence/abstract.js:888:13)
     
```